### PR TITLE
feat: completes CRUD functionality for programmes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -14,6 +14,11 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+    }),
+  );
   await app.listen(3000);
   Logger.log(`Server Running on http://localhost:3000`, 'Bootstrap');
 }

--- a/src/programmes/dto/create-programme.dto.ts
+++ b/src/programmes/dto/create-programme.dto.ts
@@ -1,1 +1,15 @@
-export class CreateProgrammeDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+import { Criteria } from '../entities/programme.entity';
+
+export class CreateProgrammeDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  description: string;
+
+  criteria: Criteria;
+}

--- a/src/programmes/entities/programme.entity.ts
+++ b/src/programmes/entities/programme.entity.ts
@@ -3,9 +3,17 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  JoinColumn,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { Task } from 'src/tasks/entities/task.entity';
+import { Status } from '../../utils/enums';
+import { Report } from 'src/reports/entities/report.entity';
+import { User } from 'src/users/entities/user.entity';
 
 export class Criteria {}
 
@@ -14,7 +22,7 @@ export class Programme {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', unique: true })
   name: string;
 
   @Column({ type: 'varchar' })
@@ -26,21 +34,48 @@ export class Programme {
   @Column({ nullable: true })
   date_completed?: Date;
 
+  @ManyToOne(() => User, { nullable: true })
+  archived_by?: User;
+
   @Column({ nullable: true })
   date_archived?: Date;
 
-  @Column({ type: 'text', nullable: true })
+  @Column({ type: 'enum', enum: Status, default: Status.ACTIVE })
+  status: Status;
+
+  @Column({ type: 'json', nullable: true })
   criteria: Criteria;
 
-  @Column()
+  @ManyToOne(() => User, { nullable: true })
+  created_by: User;
+
+  @Column({ type: 'datetime' })
   @CreateDateColumn()
   created_at?: Date;
 
-  @Column()
+  @Column({ type: 'datetime' })
   @UpdateDateColumn()
   updated_at: Date;
 
   @Column()
   @DeleteDateColumn()
   deleted_at: Date;
+
+  @OneToMany(() => Task, (program) => program.id, {
+    nullable: true,
+  })
+  @JoinColumn()
+  tasks: Task[];
+
+  @OneToMany(() => Report, (program) => program.id, {
+    nullable: true,
+  })
+  @JoinColumn()
+  report: Report[];
+
+  @ManyToMany(() => User, (program) => program.id, {
+    nullable: true,
+  })
+  @JoinColumn()
+  manager: User[];
 }

--- a/src/programmes/programmes.controller.ts
+++ b/src/programmes/programmes.controller.ts
@@ -3,45 +3,57 @@ import {
   Get,
   Post,
   Body,
-  Patch,
   Param,
-  Delete,
+  Put,
+  Query,
+  UseGuards,
+  // Delete,
 } from '@nestjs/common';
 import { ProgrammesService } from './programmes.service';
 import { CreateProgrammeDto } from './dto/create-programme.dto';
 import { UpdateProgrammeDto } from './dto/update-programme.dto';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { GetUser } from 'src/auth/decorator/get-user.decorator';
+import { User } from 'src/users/entities/user.entity';
 
-@ApiTags('Programmes')
-@Controller('programmes')
+@ApiTags('Programs')
+@Controller('programs')
 export class ProgrammesController {
   constructor(private readonly programmesService: ProgrammesService) {}
 
   @Post()
-  create(@Body() createProgrammeDto: CreateProgrammeDto) {
-    return this.programmesService.create(createProgrammeDto);
+  @UseGuards(AuthGuard())
+  @ApiBearerAuth()
+  async create(
+    @Body() createProgrammeDto: CreateProgrammeDto,
+    @GetUser() user: User,
+  ) {
+    return await this.programmesService.create(createProgrammeDto, user);
   }
 
   @Get()
-  findAll() {
-    return this.programmesService.findAll();
+  async findAll(@Query('page') page = 1, @Query('chunk') chunk = 10) {
+    return await this.programmesService.findAll(page, chunk);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.programmesService.findOne(+id);
+  async findOne(@Param('id') id: string) {
+    return await this.programmesService.findOne(+id);
   }
 
-  @Patch(':id')
-  update(
+  @Put(':id')
+  @UseGuards(AuthGuard())
+  @ApiBearerAuth()
+  async update(
     @Param('id') id: string,
     @Body() updateProgrammeDto: UpdateProgrammeDto,
   ) {
-    return this.programmesService.update(+id, updateProgrammeDto);
+    return await this.programmesService.update(+id, updateProgrammeDto);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.programmesService.remove(+id);
-  }
+  // @Delete(':id')
+  // remove(@Param('id') id: string) {
+  //   return this.programmesService.remove(+id);
+  // }
 }

--- a/src/programmes/programmes.module.ts
+++ b/src/programmes/programmes.module.ts
@@ -1,9 +1,26 @@
 import { Module } from '@nestjs/common';
 import { ProgrammesService } from './programmes.service';
 import { ProgrammesController } from './programmes.controller';
+import { Programme } from './entities/programme.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { jwtConstants } from 'src/auth/constants';
+import { JwtStrategy } from 'src/auth/jwt.strategy';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([Programme]),
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    JwtModule.register({
+      secret: jwtConstants.secret,
+      signOptions: { expiresIn: '60d' },
+    }),
+    UsersModule,
+  ],
   controllers: [ProgrammesController],
-  providers: [ProgrammesService],
+  providers: [ProgrammesService, JwtStrategy],
+  exports: [ProgrammesService],
 })
 export class ProgrammesModule {}

--- a/src/programmes/programmes.service.ts
+++ b/src/programmes/programmes.service.ts
@@ -1,26 +1,82 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateProgrammeDto } from './dto/create-programme.dto';
 import { UpdateProgrammeDto } from './dto/update-programme.dto';
+import { Programme } from './entities/programme.entity';
+import { NAME_ALREADY_EXISTS } from 'src/utils/constants';
+import { User } from 'src/users/entities/user.entity';
 
 @Injectable()
 export class ProgrammesService {
-  create(createProgrammeDto: CreateProgrammeDto) {
-    return createProgrammeDto;
+  constructor(
+    @InjectRepository(Programme)
+    private programmeRepository: Repository<Programme>,
+  ) {}
+
+  async create(createProgrammeDto: CreateProgrammeDto, createdBy: User) {
+    try {
+      const program = this.programmeRepository.create({
+        ...createProgrammeDto,
+        criteria: JSON.stringify(createProgrammeDto.criteria ?? {}, null, 2),
+        created_by: createdBy,
+      });
+
+      return await this.programmeRepository.save(program);
+    } catch (e) {
+      if (e.code === 'ER_DUP_ENTRY') {
+        throw new ConflictException(NAME_ALREADY_EXISTS);
+      }
+
+      throw e;
+    }
   }
 
-  findAll() {
-    return `This action returns all programmes`;
+  /**
+   * This action returns all programmes
+   * @highman95
+   */
+  async findAll(page = 1, chunk = 10): Promise<Programme[]> {
+    const limit = !chunk || chunk >= 100 ? 10 : chunk;
+    const offset = ((!page || page <= 0 ? 1 : page) - 1) * limit;
+
+    return await this.programmeRepository.find({
+      skip: offset,
+      take: limit,
+    });
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} programme`;
+  /**
+   * This action returns a #${id} programme
+   * @highman95
+   */
+  async findOne(param = {}): Promise<Programme> {
+    return await this.programmeRepository.findOne({ where: param });
   }
 
-  update(id: number, updateProgrammeDto: UpdateProgrammeDto) {
-    return `This action updates a #${id}  ${updateProgrammeDto}programme`;
+  /**
+   * This action updates a #${id} ${updateProgrammeDto}programme;
+   */
+  async update(
+    id: number,
+    updateProgrammeDto: UpdateProgrammeDto,
+  ): Promise<Programme> {
+    const programme = await this.programmeRepository.findOneBy({ id });
+    if (!programme) {
+      throw new NotFoundException('Programme not found');
+    }
+
+    const { name, description } = updateProgrammeDto;
+    programme.name = name;
+    programme.description = description;
+    return await this.programmeRepository.save(programme);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} programme`;
-  }
+  // remove(id: number) {
+  //   return `This action removes a #${id} programme`;
+  // }
 }

--- a/src/tasks/entities/task.entity.ts
+++ b/src/tasks/entities/task.entity.ts
@@ -3,9 +3,7 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
-  JoinColumn,
   ManyToOne,
-  OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
@@ -30,10 +28,10 @@ export class Task {
   @Column({ type: 'text' })
   description: string;
 
-  @Column({ type: 'enum', enum: TaskStatus, default: TaskStatus.UNASSIGNED, })
+  @Column({ type: 'enum', enum: TaskStatus, default: TaskStatus.UNASSIGNED })
   status: TaskStatus;
 
-  @ManyToOne(() => Programme, { cascade: true, })
+  @ManyToOne(() => Programme, { cascade: true })
   programme: Programme;
 
   @ManyToOne(() => User)
@@ -43,13 +41,13 @@ export class Task {
   @CreateDateColumn()
   created_at: Date;
 
-  @ManyToOne(() => User, { nullable: true, })
+  @ManyToOne(() => User, { nullable: true })
   assigned_to: User;
 
-  @ManyToOne(() => User, { nullable: true, })
+  @ManyToOne(() => User, { nullable: true })
   assigned_by: User;
 
-  @Column({ type: 'datetime', nullable: true})
+  @Column({ type: 'datetime', nullable: true })
   assigned_at: Date;
 
   @ManyToOne(() => User)
@@ -59,7 +57,7 @@ export class Task {
   @UpdateDateColumn()
   last_updated_at: Date;
 
-  @ManyToOne(() => User, { nullable: true, })
+  @ManyToOne(() => User, { nullable: true })
   deleted_by: User;
 
   @Column()

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -79,7 +79,7 @@ export class User extends BaseEntity {
   @Column({ nullable: true })
   dob: Date;
 
-  @Column({ enum: UserRoles, default: UserRoles.Mentor })
+  @Column({ type: 'enum', enum: UserRoles, default: UserRoles.Mentor })
   role: UserRoles;
 
   @Column({ type: 'varchar' })

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,2 @@
+// 409s
+export const NAME_ALREADY_EXISTS = 'Name already exists';

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -1,0 +1,5 @@
+export enum Status {
+  ACTIVE = 'active',
+  COMPLETED = 'completed',
+  ARCHIVED = 'archived',
+}


### PR DESCRIPTION
This completes endpoints for the following operations
- Create programme (POST /programs)
- Update programme (PUT /programs/:id)
- Get all programmes (GET /programs)
- Get programme detail (GET /programs/:id)

It also
- Fixes a bug that blocks migration of user entity in mariadb
- Resolves some lint issues